### PR TITLE
feat: support configurable voice toggle shortcut

### DIFF
--- a/extensions/voice.ts
+++ b/extensions/voice.ts
@@ -52,7 +52,7 @@
  *
  * Activation:
  *   - Hold SPACE (≥1200ms) → release to finalize
- *   - Ctrl+Shift+V → toggle start/stop (always works)
+ *   - Configurable shortcut → toggle start/stop (always works)
 
  *
  * Config in ~/.pi/agent/settings.json under "voice": { ... }
@@ -72,6 +72,7 @@ import * as path from "node:path";
 import {
 	DEFAULT_CONFIG,
 	loadConfigWithSource,
+	loadGlobalConfig,
 	saveConfig,
 	type VoiceConfig,
 	type VoiceSettingsScope,
@@ -645,6 +646,17 @@ export default function (pi: ExtensionAPI) {
 	let errorCooldownUntil = 0;       // After an error, block re-activation until this timestamp
 	let lastNonSpaceKeyTime = 0;      // Timestamp of last non-space keypress (typing cooldown)
 	let tailRecordingTimer: ReturnType<typeof setTimeout> | null = null; // Delayed stop after release
+
+	function getToggleShortcut(): string {
+		return loadGlobalConfig().toggleShortcut || DEFAULT_CONFIG.toggleShortcut || "ctrl+shift+v";
+	}
+
+	function getShortcutLabel(shortcut: string): string {
+		return shortcut
+			.split("+")
+			.map((part) => part.length <= 1 ? part.toUpperCase() : part[0]!.toUpperCase() + part.slice(1))
+			.join("+");
+	}
 
 	// ─── Recording History ───────────────────────────────────────────────────
 
@@ -1754,7 +1766,7 @@ export default function (pi: ExtensionAPI) {
 
 	// ─── Shortcuts ───────────────────────────────────────────────────────────
 
-	pi.registerShortcut("ctrl+shift+v", {
+	pi.registerShortcut(loadGlobalConfig().toggleShortcut || DEFAULT_CONFIG.toggleShortcut || "ctrl+shift+v", {
 		description: "Toggle voice recording (start/stop)",
 		handler: async (handlerCtx) => {
 			ctx = handlerCtx;
@@ -1763,7 +1775,7 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			if (dictationMode) {
-				// Ctrl+Shift+V stops dictation mode
+				// The configured toggle shortcut stops dictation mode
 				dictationMode = false;
 				if (voiceState === "recording") {
 					await stopVoiceRecording();
@@ -1835,7 +1847,7 @@ export default function (pi: ExtensionAPI) {
 						"pi-listen ready!",
 						"",
 						"  Hold SPACE to record → release to transcribe",
-						"  Ctrl+Shift+V to toggle recording",
+						`  ${getShortcutLabel(getToggleShortcut())} to toggle recording`,
 						`  Backend: ${backendLabel}`,
 						`  Audio: ${audioTool ? `${audioTool.name}` : "NONE — install sox or ffmpeg"}`,
 						"",
@@ -1908,7 +1920,7 @@ export default function (pi: ExtensionAPI) {
 					backendInfo,
 					"",
 					"  Hold SPACE → release to transcribe",
-					"  Ctrl+Shift+V → toggle recording on/off",
+					`  ${getShortcutLabel(getToggleShortcut())} → toggle recording on/off`,
 					"  Quick SPACE tap → types a space (no voice)",
 					"  Escape × 2 → clear editor",
 					"",
@@ -1972,7 +1984,7 @@ export default function (pi: ExtensionAPI) {
 						"",
 						"  Speak freely — no need to hold SPACE.",
 						"  /voice stop → finalize and stop",
-						"  Ctrl+Shift+V → also stops dictation",
+						`  ${getShortcutLabel(getToggleShortcut())} → also stops dictation`,
 					].join("\n"), "info");
 				} else {
 					dictationMode = false;
@@ -2032,6 +2044,7 @@ export default function (pi: ExtensionAPI) {
 				lines.push(`    language:          ${config.language}`);
 				lines.push(`    onboarding:        ${config.onboarding.completed ? "complete" : "incomplete"}`);
 				lines.push(`    hold threshold:    ${HOLD_THRESHOLD_MS}ms`);
+				lines.push(`    toggle shortcut:   ${getToggleShortcut()}`);
 				lines.push(`    kitty protocol:    ${kittyReleaseDetected ? "detected" : "not detected"}`);
 				lines.push(`    state:             ${voiceState}`);
 
@@ -2133,7 +2146,7 @@ export default function (pi: ExtensionAPI) {
 						lines.push("    Or any OpenAI-compatible transcription server");
 					} else {
 						lines.push("  All checks passed — voice is ready!");
-						lines.push("  Hold SPACE to record, or use Ctrl+Shift+V to toggle.");
+						lines.push(`  Hold SPACE to record, or use ${getShortcutLabel(getToggleShortcut())} to toggle.`);
 					}
 				} else if (isLocal) {
 					// In-process sherpa-onnx mode — no server needed
@@ -2144,7 +2157,7 @@ export default function (pi: ExtensionAPI) {
 						lines.push("    apt install sox        # Linux");
 					} else {
 						lines.push("  All checks passed — voice is ready (in-process sherpa-onnx)!");
-						lines.push("  Hold SPACE to record, or use Ctrl+Shift+V to toggle.");
+						lines.push(`  Hold SPACE to record, or use ${getShortcutLabel(getToggleShortcut())} to toggle.`);
 					}
 				} else {
 					ready = !!dgKey && !!tool;
@@ -2162,7 +2175,7 @@ export default function (pi: ExtensionAPI) {
 						lines.push("    choco install sox      # Windows");
 					} else {
 						lines.push("  All checks passed — voice is ready!");
-						lines.push("  Hold SPACE to record, or use Ctrl+Shift+V to toggle.");
+						lines.push(`  Hold SPACE to record, or use ${getShortcutLabel(getToggleShortcut())} to toggle.`);
 					}
 				}
 

--- a/extensions/voice/config.ts
+++ b/extensions/voice/config.ts
@@ -37,6 +37,8 @@ export interface VoiceConfig {
 	localModel?: string;
 	/** Local transcription server URL (default: http://localhost:8080) */
 	localEndpoint?: string;
+	/** Global-only shortcut used to toggle recording without hold-to-talk */
+	toggleShortcut?: string;
 }
 
 export interface LoadedVoiceConfig {
@@ -59,6 +61,7 @@ export const DEFAULT_CONFIG: VoiceConfig = {
 	backend: undefined, // undefined = "deepgram" (default)
 	localModel: undefined,
 	localEndpoint: undefined,
+	toggleShortcut: "ctrl+shift+v",
 	onboarding: {
 		completed: false,
 		schemaVersion: VOICE_CONFIG_VERSION,
@@ -115,6 +118,9 @@ function migrateConfig(rawVoice: any, source: VoiceConfigSource): VoiceConfig {
 		backend: rawVoice.backend === "local" ? "local" : undefined,
 		localModel: typeof rawVoice.localModel === "string" ? rawVoice.localModel : undefined,
 		localEndpoint: typeof rawVoice.localEndpoint === "string" ? rawVoice.localEndpoint : undefined,
+		toggleShortcut: source !== "project" && typeof rawVoice.toggleShortcut === "string"
+			? rawVoice.toggleShortcut
+			: DEFAULT_CONFIG.toggleShortcut,
 		onboarding: normalizeOnboarding(rawVoice.onboarding, fallbackCompleted),
 	};
 }
@@ -151,6 +157,15 @@ export function loadConfigWithSource(cwd: string, options: ConfigPathOptions = {
 	};
 }
 
+export function loadGlobalConfig(options: ConfigPathOptions = {}): VoiceConfig {
+	const globalSettingsPath = getGlobalSettingsPath(options);
+	const globalVoice = readJsonFile(globalSettingsPath)[SETTINGS_KEY];
+	if (globalVoice && typeof globalVoice === "object") {
+		return migrateConfig(globalVoice, "global");
+	}
+	return structuredClone(DEFAULT_CONFIG);
+}
+
 /** Check if a URL points to a loopback address (localhost/127.0.0.1/::1). */
 export function isLoopbackEndpoint(endpoint: string): boolean {
 	try {
@@ -174,6 +189,9 @@ function serializeConfig(config: VoiceConfig, scope: VoiceSettingsScope): VoiceC
 		localEndpoint: (scope === "project" && config.localEndpoint && !isLoopbackEndpoint(config.localEndpoint))
 			? undefined
 			: config.localEndpoint,
+		// Shortcut registration is static at extension load time, so project-scoped
+		// overrides cannot be applied correctly.
+		toggleShortcut: scope === "project" ? undefined : config.toggleShortcut,
 		onboarding: {
 			...config.onboarding,
 			schemaVersion: VOICE_CONFIG_VERSION,


### PR DESCRIPTION
Summary:
- add voice.toggleShortcut to the voice config
- bind the toggle shortcut from global voice config at startup
- surface the configured shortcut in setup/help/test output
- enforce global-only semantics so project config cannot claim a shortcut that Pi cannot actually bind

Notes:
- kept the default binding as ctrl+shift+v
- this PR is intentionally separate from the Linux hold-to-talk fix
- shortcut registration in Pi is static at extension load time, so project-scoped overrides are explicitly ignored
- I did not include the Deepgram key persistence change because that is already being handled separately upstream