### PR TITLE
feat: add configurable hold-to-talk key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Configurable hold-to-talk key** — `voice.holdKey` lets users choose the
+  key used for hold-to-talk activation instead of always using Space.
+
 ## [7.2.2] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ See your hardware profile (RAM, CPU, GPU), dependency status (sherpa-onnx runtim
 
 | Action | Key | Notes |
 |--------|-----|-------|
-| **Record to editor** | Hold `SPACE` (≥1.2s) | Release to finalize. Pre-records during warmup so you don't miss words. |
+| **Record to editor** | Hold configured key (`SPACE` by default, ≥1.2s) | Release to finalize. Pre-records during warmup so you don't miss words. |
 | **Toggle recording** | `Ctrl+Shift+V` | Works in all terminals — press to start, press again to stop. |
 | **Clear editor** | `Escape` × 2 | Double-tap within 500ms to clear all text. |
 
 ### How recording works
 
-1. **Hold SPACE** — warmup countdown appears, audio capture starts immediately (pre-recording)
+1. **Hold the configured key** — warmup countdown appears, audio capture starts immediately (pre-recording)
 2. **Keep holding** — live transcription streams into the editor (Deepgram) or audio buffers (local)
 3. **Release SPACE** — recording continues for 1.5s (tail recording) to catch your last word, then finalizes
 4. Text appears in the editor, ready to send
@@ -216,7 +216,7 @@ Plus 8 language-specialized Moonshine v2 variants for Japanese, Korean, Arabic, 
 ### How local models work
 
 ```
-Hold SPACE → audio captured to memory buffer
+Hold configured key → audio captured to memory buffer
                 ↓
 Release SPACE → buffer sent to sherpa-onnx (in-process)
                 ↓
@@ -287,6 +287,7 @@ Settings stored in Pi's settings files under the `voice` key:
     "backend": "local",
     "localModel": "parakeet-v3",
     "scope": "global",
+    "holdKey": "space",
     "onboarding": { "completed": true, "schemaVersion": 2 }
   }
 }
@@ -295,6 +296,10 @@ Settings stored in Pi's settings files under the `voice` key:
 `DEEPGRAM_API_KEY` from your shell is used at runtime and is not copied back
 into `~/.pi/agent/settings.json`. If you paste a key during onboarding, that is
 an explicit save and it still goes to `~/.env.secrets` or `~/.zshrc`.
+
+Set `holdKey` to change the key used for hold-to-talk activation. The default
+is `space`; examples include `alt+r`, `ctrl+shift+v`, or `f8`. Non-space hold
+keys are consumed while detecting a hold so they do not type into the editor.
 
 ---
 

--- a/extensions/voice.ts
+++ b/extensions/voice.ts
@@ -72,6 +72,7 @@ import * as path from "node:path";
 import {
 	DEFAULT_CONFIG,
 	getSessionStartPersistedConfig,
+	isValidHoldKey,
 	loadConfigWithSource,
 	loadGlobalToggleShortcut,
 	saveConfig,
@@ -667,6 +668,19 @@ export default function (pi: ExtensionAPI) {
 		const v = (config as any).holdThresholdMs;
 		if (typeof v === "number" && Number.isFinite(v) && v >= 200 && v <= 3000) return v;
 		return HOLD_THRESHOLD_DEFAULT_MS;
+	}
+
+	function getHoldKey(): string {
+		const v = (config as any).holdKey;
+		if (typeof v === "string" && isValidHoldKey(v)) return v;
+		return DEFAULT_CONFIG.holdKey || "space";
+	}
+
+	function formatKeyLabel(keyId: string): string {
+		return keyId
+			.split("+")
+			.map((p) => p.length <= 1 ? p.toUpperCase() : p[0]!.toUpperCase() + p.slice(1))
+			.join("+");
 	}
 
 	// ─── Toggle Shortcut (resolved once at startup, used everywhere) ──────
@@ -1517,6 +1531,7 @@ export default function (pi: ExtensionAPI) {
 
 	function onSpaceReleaseDetected() {
 		releaseDetectTimer = null;
+		const holdKeyLabel = formatKeyLabel(getHoldKey());
 		voiceDebug("onSpaceReleaseDetected", { voiceState, holdConfirmed, spaceConsumed, spaceDownTime, spacePressCount, timeSinceRecStart: spaceConsumed ? Date.now() - recordingStartedAt : null });
 
 		// If we never confirmed this was a hold (< REPEAT_CONFIRM_COUNT rapid presses),
@@ -1542,7 +1557,7 @@ export default function (pi: ExtensionAPI) {
 			spacePressCount = 0;
 			holdConfirmed = false;
 			// Don't type a space — user clearly intended to trigger voice but let go too early
-			ctx?.ui.notify("Hold SPACE longer to activate voice.", "info");
+			ctx?.ui.notify(`Hold ${holdKeyLabel} longer to activate voice.`, "info");
 			return;
 		}
 
@@ -1586,6 +1601,11 @@ export default function (pi: ExtensionAPI) {
 		terminalInputUnsub = ctx.ui.onTerminalInput((data: string) => {
 			if (!config.enabled) return undefined;
 
+			const holdKey = getHoldKey();
+			const holdKeyIsSpace = holdKey === "space";
+			const holdKeyLabel = formatKeyLabel(holdKey);
+			const isHoldKey = matchesKey(data, holdKey as KeyId);
+
 			// v7.1 §4 — escape priority routing for v7.1 widgets. When
 			// no overlay (panel/help/picker) is in front (those run
 			// inside ctx.ui.custom() and consume their own input), the
@@ -1614,34 +1634,35 @@ export default function (pi: ExtensionAPI) {
 				return { consume: true };
 			}
 
-			// ── Track non-space keypresses for typing cooldown ──
-			// If user was just typing (non-space key within TYPING_COOLDOWN_MS),
+			// ── Track non-hold keypresses for typing cooldown ──
+			// If user was just typing (non-hold key within TYPING_COOLDOWN_MS),
 			// don't let space holds activate voice — they're just typing.
-			if (!matchesKey(data, "space") && !isKeyRelease(data) && !isKeyRepeat(data)) {
-				// Regular keypress that isn't space — user is typing
+			if (!isHoldKey && !isKeyRelease(data) && !isKeyRepeat(data)) {
+				// Regular keypress that isn't the hold key — user is typing
 				if (data.length > 0 && data.charCodeAt(0) >= 32) {
 					lastNonSpaceKeyTime = Date.now();
 				}
 			}
 
-			// ── SPACE handling ──
-			if (matchesKey(data, "space")) {
+			// ── Hold-to-talk key handling ──
+			if (isHoldKey) {
 				// ── ERROR COOLDOWN: block all voice activation for 5s after an error ──
 				if (errorCooldownUntil > Date.now()) {
-					// During cooldown, let space through as a normal character
-					return undefined;
+					// During cooldown, let space through as a normal character.
+					// Non-space hold keys are consumed to avoid accidental editor input.
+					return holdKeyIsSpace ? undefined : { consume: true };
 				}
 
 				// ── TYPING COOLDOWN: if user was just typing, let space through ──
 				// Apple-style: if a non-space key was pressed recently, this space
 				// is part of typing (e.g., "hello world"), not a voice activation.
 				// Only applies to NEW activations — don't interrupt active recording.
-				if (voiceState === "idle" && !spaceConsumed &&
+				if (holdKeyIsSpace && voiceState === "idle" && !spaceConsumed &&
 					lastNonSpaceKeyTime > 0 && (Date.now() - lastNonSpaceKeyTime) < TYPING_COOLDOWN_MS) {
 					return undefined;
 				}
 
-				voiceDebug("SPACE event", {
+				voiceDebug("hold key event", {
 					isRelease: isKeyRelease(data),
 					isRepeat: isKeyRepeat(data),
 					voiceState,
@@ -1650,6 +1671,7 @@ export default function (pi: ExtensionAPI) {
 					spaceConsumed,
 					spacePressCount,
 					spaceDownTime: spaceDownTime ? Date.now() - spaceDownTime : null,
+					holdKey,
 					dataHex: Buffer.from(data).toString("hex"),
 				});
 
@@ -1669,11 +1691,12 @@ export default function (pi: ExtensionAPI) {
 						hideWidget();
 						setVoiceState("idle");
 						if (holdDuration < 300) {
-							// Quick tap — just type a space
-							if (ctx?.hasUI) ctx.ui.setEditorText((ctx.ui.getEditorText() || "") + " ");
+							// Quick space tap — just type a space. Other configured hold keys
+							// are consumed so they don't leak into the editor.
+							if (holdKeyIsSpace && ctx?.hasUI) ctx.ui.setEditorText((ctx.ui.getEditorText() || "") + " ");
 						} else {
 							// Held long enough to see warmup but let go → show hint
-							ctx?.ui.notify("Hold SPACE longer to activate voice.", "info");
+							ctx?.ui.notify(`Hold ${holdKeyLabel} longer to activate voice.`, "info");
 						}
 						return { consume: true };
 					}
@@ -1682,7 +1705,7 @@ export default function (pi: ExtensionAPI) {
 					// Kitty path since we enter warmup on first press, but handle anyway)
 					if (spaceDownTime && !holdConfirmed && voiceState === "idle") {
 						resetHoldState();
-						if (ctx?.hasUI) ctx.ui.setEditorText((ctx.ui.getEditorText() || "") + " ");
+						if (holdKeyIsSpace && ctx?.hasUI) ctx.ui.setEditorText((ctx.ui.getEditorText() || "") + " ");
 						return { consume: true };
 					}
 
@@ -1803,10 +1826,10 @@ export default function (pi: ExtensionAPI) {
 					spaceDownTime = Date.now();
 					holdConfirmed = true;
 					if (!kittyReleaseDetected) {
-						voiceDebug("SPACE during recording → cancel delayed stop, re-arm release detect");
+						voiceDebug("hold key during recording → cancel delayed stop, re-arm release detect");
 						resetReleaseDetect();
 					} else {
-						voiceDebug("SPACE during recording → cancel delayed stop (Kitty)");
+						voiceDebug("hold key during recording → cancel delayed stop (Kitty)");
 					}
 					return { consume: true };
 				}
@@ -1814,7 +1837,7 @@ export default function (pi: ExtensionAPI) {
 				// If already in warmup → consume
 				if (voiceState === "warmup") {
 					if (!kittyReleaseDetected) {
-						voiceDebug("SPACE during warmup → re-arm release detect");
+						voiceDebug("hold key during warmup → re-arm release detect");
 						resetReleaseDetect();
 					}
 					return { consume: true };
@@ -1825,7 +1848,7 @@ export default function (pi: ExtensionAPI) {
 				// voiceState transitioning to "recording" (async gap)
 				if (spaceConsumed) {
 					if (!kittyReleaseDetected) {
-						voiceDebug("SPACE while spaceConsumed (async gap) → re-arm release detect");
+						voiceDebug("hold key while spaceConsumed (async gap) → re-arm release detect");
 						resetReleaseDetect();
 					}
 					return { consume: true };
@@ -1956,10 +1979,11 @@ export default function (pi: ExtensionAPI) {
 					}
 				}
 
-				// IDLE — first SPACE press (non-Kitty path)
-				// Do NOT consume — let it pass through to whatever UI is focused
-				// (editor, search box, picker, etc.). Only start consuming after
-				// we confirm it's a hold via REPEAT_CONFIRM_COUNT rapid presses.
+				// IDLE — first hold-key press (non-Kitty path)
+				// For SPACE, do NOT consume — let it pass through to whatever UI is
+				// focused (editor, search box, picker, etc.). For non-space keys,
+				// consume immediately so configured activation keys don't type text.
+				// After confirming a hold, all repeats are consumed.
 				if (voiceState === "idle") {
 					spaceDownTime = Date.now();
 					spaceConsumed = false;
@@ -1969,8 +1993,9 @@ export default function (pi: ExtensionAPI) {
 
 					resetReleaseDetect();
 
-					// Don't consume — let the space reach the focused UI component
-					return undefined;
+					// Don't consume space — let it reach the focused UI component.
+					// Do consume non-space hold keys to avoid editor input.
+					return holdKeyIsSpace ? undefined : { consume: true };
 				}
 
 				if (spaceConsumed) return { consume: true };
@@ -2163,10 +2188,11 @@ export default function (pi: ExtensionAPI) {
 			const backendLabel = hasLocalModel
 				? `Local model: ${LOCAL_MODELS.find(m => m.id === config.localModel)?.name || config.localModel} (offline, batch mode)`
 				: "Deepgram Nova-3 (cloud, live streaming)";
+			const holdKeyLabel = formatKeyLabel(getHoldKey());
 			const lines = [
 				"pi-listen ready!",
 				"",
-				"  Hold SPACE to record → release to transcribe",
+				`  Hold ${holdKeyLabel} to record → release to transcribe`,
 				`  ${toggleShortcutLabel} to toggle recording`,
 				`  Backend: ${backendLabel}`,
 				`  Audio: ${audioTool ? `${audioTool.name}` : "NONE — install sox or ffmpeg"}`,
@@ -2462,12 +2488,13 @@ export default function (pi: ExtensionAPI) {
 				const backendInfo = config.backend === "local"
 					? `Voice enabled (local model: ${config.localModel || "whisper-small"}).`
 					: "Voice enabled (Deepgram streaming).";
+				const holdKeyLabel = formatKeyLabel(getHoldKey());
 				cmdCtx.ui.notify([
 					backendInfo,
 					"",
-					"  Hold SPACE → release to transcribe",
+					`  Hold ${holdKeyLabel} → release to transcribe`,
 					`  ${toggleShortcutLabel} → toggle recording on/off`,
-					"  Quick SPACE tap → types a space (no voice)",
+					holdKeyLabel === "Space" ? "  Quick SPACE tap → types a space (no voice)" : `  Quick ${holdKeyLabel} tap → consumed (no voice)`,
 					"  Escape × 2 → clear editor",
 					"",
 					"  /voice-settings → open settings panel",
@@ -2525,10 +2552,11 @@ export default function (pi: ExtensionAPI) {
 				editorTextBeforeVoice = ctx?.hasUI ? (ctx.ui.getEditorText() || "") : "";
 				const ok = await startVoiceRecording();
 				if (ok) {
+					const holdKeyLabel = formatKeyLabel(getHoldKey());
 					cmdCtx.ui.notify([
 						"🎤 Continuous dictation mode active.",
 						"",
-						"  Speak freely — no need to hold SPACE.",
+						`  Speak freely — no need to hold ${holdKeyLabel}.`,
 						"  /voice stop → finalize and stop",
 						`  ${toggleShortcutLabel} → also stops dictation`,
 					].join("\n"), "info");
@@ -2691,8 +2719,9 @@ export default function (pi: ExtensionAPI) {
 						lines.push("    whisper.cpp: ./build/bin/whisper-server -m models/ggml-small.bin --port 8080");
 						lines.push("    Or any OpenAI-compatible transcription server");
 					} else {
+						const holdKeyLabel = formatKeyLabel(getHoldKey());
 						lines.push("  All checks passed — voice is ready!");
-						lines.push(`  Hold SPACE to record, or use ${toggleShortcutLabel} to toggle.`);
+						lines.push(`  Hold ${holdKeyLabel} to record, or use ${toggleShortcutLabel} to toggle.`);
 					}
 				} else if (isLocal) {
 					// In-process sherpa-onnx mode — no server needed
@@ -2702,8 +2731,9 @@ export default function (pi: ExtensionAPI) {
 						lines.push("    brew install sox       # macOS (recommended)");
 						lines.push("    apt install sox        # Linux");
 					} else {
+						const holdKeyLabel = formatKeyLabel(getHoldKey());
 						lines.push("  All checks passed — voice is ready (in-process sherpa-onnx)!");
-						lines.push(`  Hold SPACE to record, or use ${toggleShortcutLabel} to toggle.`);
+						lines.push(`  Hold ${holdKeyLabel} to record, or use ${toggleShortcutLabel} to toggle.`);
 					}
 				} else {
 					ready = !!dgKey && !!tool;
@@ -2720,8 +2750,9 @@ export default function (pi: ExtensionAPI) {
 						lines.push("    apt install ffmpeg     # Linux (alternative)");
 						lines.push("    choco install sox      # Windows");
 					} else {
+						const holdKeyLabel = formatKeyLabel(getHoldKey());
 						lines.push("  All checks passed — voice is ready!");
-						lines.push(`  Hold SPACE to record, or use ${toggleShortcutLabel} to toggle.`);
+						lines.push(`  Hold ${holdKeyLabel} to record, or use ${toggleShortcutLabel} to toggle.`);
 					}
 				}
 
@@ -2773,8 +2804,9 @@ export default function (pi: ExtensionAPI) {
 
 	async function openHelpOverlay(cmdCtx: ExtensionCommandContext): Promise<void> {
 		if (!cmdCtx.hasUI) {
+			const holdKeyLabel = formatKeyLabel(getHoldKey());
 			cmdCtx.ui.notify(
-				"pi-listen: hold space=record · /voice-speak <text> · /voice-settings · /voice-help",
+				`pi-listen: hold ${holdKeyLabel}=record · /voice-speak <text> · /voice-settings · /voice-help`,
 				"info",
 			);
 			return;

--- a/extensions/voice/config.ts
+++ b/extensions/voice/config.ts
@@ -39,6 +39,8 @@ export interface VoiceConfig {
 	localEndpoint?: string;
 	/** Global-only shortcut used to toggle recording without hold-to-talk */
 	toggleShortcut?: string;
+	/** Key held to activate push-to-talk recording. Defaults to "space". */
+	holdKey?: string;
 
 	// ─── TTS (text-to-speech) ─────────────────────────────────────────
 	// All TTS fields are opt-in (default: TTS disabled). New in v6.0.0.
@@ -125,6 +127,7 @@ export const DEFAULT_CONFIG: VoiceConfig = {
 	localModel: undefined,
 	localEndpoint: undefined,
 	toggleShortcut: "ctrl+shift+v",
+	holdKey: "space",
 	// TTS defaults — all opt-in
 	ttsEnabled: false,
 	ttsBackend: "local",
@@ -197,6 +200,9 @@ function migrateConfig(rawVoice: any, source: VoiceConfigSource): VoiceConfig {
 		toggleShortcut: source !== "project" && typeof rawVoice.toggleShortcut === "string"
 			? rawVoice.toggleShortcut
 			: DEFAULT_CONFIG.toggleShortcut,
+		holdKey: typeof rawVoice.holdKey === "string" && isValidHoldKey(rawVoice.holdKey)
+			? rawVoice.holdKey
+			: DEFAULT_CONFIG.holdKey,
 		// TTS fields — type-validated; mismatched persisted values fall
 		// back to safe defaults so a hand-edited config can't poison the
 		// engine. Notably: ttsLocalVoiceId rejects strings (would crash
@@ -283,6 +289,11 @@ export function isValidShortcut(shortcut: string): boolean {
 	if (key.length === 0) return false;
 	const mods = parts.slice(0, -1);
 	return mods.every((m) => VALID_MODIFIERS.has(m));
+}
+
+/** Validate a hold-to-talk key id like "space", "alt+v", or "f8". */
+export function isValidHoldKey(keyId: string): boolean {
+	return isValidShortcut(keyId);
 }
 
 /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,6 +6,7 @@ import {
 	DEFAULT_CONFIG,
 	getSessionStartPersistedConfig,
 	isLoopbackEndpoint,
+	isValidHoldKey,
 	loadConfigWithSource,
 	needsOnboarding,
 	saveConfig,
@@ -75,6 +76,32 @@ describe("loadConfigWithSource", () => {
 
 		expect(result.source).toBe("global");
 		expect(result.config.onboarding.completed).toBe(false);
+	});
+
+	test("loads configured hold key from settings", () => {
+		const cwd = makeTempDir();
+		const agentDir = path.join(cwd, "agent-home");
+		writeSettings(agentDir, "settings.json", {
+			enabled: true,
+			holdKey: "alt+r",
+		});
+
+		const result = loadConfigWithSource(cwd, { agentDir });
+
+		expect(result.config.holdKey).toBe("alt+r");
+	});
+
+	test("falls back to default hold key for invalid settings", () => {
+		const cwd = makeTempDir();
+		const agentDir = path.join(cwd, "agent-home");
+		writeSettings(agentDir, "settings.json", {
+			enabled: true,
+			holdKey: "alt v",
+		});
+
+		const result = loadConfigWithSource(cwd, { agentDir });
+
+		expect(result.config.holdKey).toBe(DEFAULT_CONFIG.holdKey);
 	});
 
 	test("prefers project config over global config and preserves project scope", () => {
@@ -280,6 +307,21 @@ describe("saveConfig", () => {
 
 		expect(tmpFiles).toHaveLength(0);
 		expect(JSON.parse(fs.readFileSync(savedPath, "utf8"))).toBeDefined();
+	});
+});
+
+describe("isValidHoldKey", () => {
+	test("accepts plain and modified key ids", () => {
+		expect(isValidHoldKey("space")).toBe(true);
+		expect(isValidHoldKey("alt+r")).toBe(true);
+		expect(isValidHoldKey("ctrl+shift+v")).toBe(true);
+		expect(isValidHoldKey("f8")).toBe(true);
+	});
+
+	test("rejects malformed key ids", () => {
+		expect(isValidHoldKey("")).toBe(false);
+		expect(isValidHoldKey("alt r")).toBe(false);
+		expect(isValidHoldKey("hyper+r")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Add `voice.holdKey` config for hold-to-talk activation
- Default remains `space` for backward compatibility
- Allow alternatives such as `alt+r`, `ctrl+shift+v`, or `f8`
- Consume non-space hold keys while detecting holds so they do not type into the editor
- Update user-facing labels, README, changelog, and config tests

## Testing

- `npx bun test` — 275 pass, 0 fail

## Notes

- `npx bun run check` is known to fail during typecheck on existing unrelated errors in `extensions/voice.ts` and `extensions/voice/tts-deepgram.ts`, same as the previous PR.
