### PR TITLE
feat: add Deepgram Aura 2 voices and TTS/STT fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Restore legacy Deepgram Aura voices below Aura 2 in the TTS voice picker while keeping Aura 2 as the default selection.
+
 ## [7.2.2] - 2026-05-01
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,13 @@
   "workspaces": {
     "": {
       "name": "pi-voice",
+      "dependencies": {
+        "ws": "^8.20.1",
+      },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "^0.70.5",
         "@mariozechner/pi-tui": "^0.70.5",
+        "@types/ws": "^8.18.1",
       },
       "optionalDependencies": {
         "sherpa-onnx-node": "^1.13.0",
@@ -259,6 +263,8 @@
     "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -540,7 +546,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -570,9 +576,13 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@google/genai/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@mistralai/mistralai/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/extensions/voice.ts
+++ b/extensions/voice.ts
@@ -422,7 +422,11 @@ function startStreamingSession(
 		recProc.stdout?.on("data", (chunk: Buffer) => {
 			if (ws.readyState === WebSocket.OPEN) {
 				session.hadAudioData = true;
-				try { ws.send(chunk); } catch {}
+				const audioFrame = chunk.buffer.slice(
+					chunk.byteOffset,
+					chunk.byteOffset + chunk.byteLength,
+				) as ArrayBuffer;
+				try { ws.send(audioFrame); } catch {}
 				// Feed audio data to level meter for reactive waveform
 				updateAudioLevel(chunk);
 				// Start stale-session watchdog on first audio chunk
@@ -3352,7 +3356,7 @@ export default function (pi: ExtensionAPI) {
 			ctx = cmdCtx;
 			const { getTtsModel, isTtsModelInstalled, TTS_LOCAL_MODELS } =
 				await import("./voice/tts-local-models");
-			const { DEEPGRAM_TTS_VOICES } = await import("./voice/tts-deepgram");
+			const { DEEPGRAM_TTS_VOICES, DEFAULT_DEEPGRAM_TTS_VOICE } = await import("./voice/tts-deepgram");
 			const { resolveDeepgramApiKey } = await import("./voice/deepgram");
 
 			const isLocal = (config.ttsBackend ?? "local") === "local";
@@ -3382,7 +3386,7 @@ export default function (pi: ExtensionAPI) {
 				lines.push("");
 				lines.push(`  Catalog:      ${TTS_LOCAL_MODELS.length} models available — /voice-speak-models to browse`);
 			} else {
-				const voiceId = config.ttsDeepgramVoiceId ?? "aura-asteria-en";
+				const voiceId = config.ttsDeepgramVoiceId ?? DEFAULT_DEEPGRAM_TTS_VOICE;
 				const voice = DEEPGRAM_TTS_VOICES.find(v => v.id === voiceId);
 				const apiKey = resolveDeepgramApiKey(config);
 				lines.push("  Deepgram backend:");

--- a/extensions/voice/config.ts
+++ b/extensions/voice/config.ts
@@ -56,9 +56,9 @@ export interface VoiceConfig {
 	 */
 	ttsLocalVoiceId?: number;
 	/**
-	 * Deepgram backend voice id (e.g. "aura-asteria-en"). Type-validated
+	 * Deepgram backend voice id (e.g. "aura-2-thalia-en"). Type-validated
 	 * at config load — numbers get rejected and fall back to
-	 * "aura-asteria-en".
+	 * the default Aura-2 voice.
 	 */
 	ttsDeepgramVoiceId?: string;
 	/** Speech rate multiplier; range 0.5–2.0. Default 1.0. */
@@ -130,7 +130,7 @@ export const DEFAULT_CONFIG: VoiceConfig = {
 	ttsBackend: "local",
 	ttsLocalModel: "kitten-nano-en-v0_2",
 	ttsLocalVoiceId: 0,
-	ttsDeepgramVoiceId: "aura-asteria-en",
+	ttsDeepgramVoiceId: "aura-2-thalia-en",
 	ttsSpeed: 1.0,
 	ttsAutoSpeak: true,
 	autoSubmitOnSpeak: false,

--- a/extensions/voice/settings-panel.ts
+++ b/extensions/voice/settings-panel.ts
@@ -32,6 +32,7 @@ import {
 } from "./tts-local-models";
 import {
 	DEEPGRAM_TTS_VOICES,
+	DEFAULT_DEEPGRAM_TTS_VOICE,
 	filterDeepgramVoicesByLanguage,
 } from "./tts-deepgram";
 import { PickerChassis, type PickerRow } from "./ui-picker";
@@ -732,7 +733,7 @@ export class VoiceSettingsPanel {
 			const voice = model?.voices.find(v => v.sid === sid);
 			return voice ? `${shortName} · ${voice.name}` : `${shortName} · sid ${sid}`;
 		}
-		return config.ttsDeepgramVoiceId ?? "aura-asteria-en";
+		return config.ttsDeepgramVoiceId ?? DEFAULT_DEEPGRAM_TTS_VOICE;
 	}
 
 	private formatLocalModelLabel(id: string | undefined): string {
@@ -753,7 +754,7 @@ export class VoiceSettingsPanel {
 			const voice = model?.voices.find(v => v.sid === sid);
 			return voice ? `${voice.name} (sid ${sid})` : `sid ${sid}`;
 		}
-		return config.ttsDeepgramVoiceId ?? "aura-asteria-en";
+		return config.ttsDeepgramVoiceId ?? DEFAULT_DEEPGRAM_TTS_VOICE;
 	}
 
 	// ─── Device tab ───────────────────────────────────────────────────────
@@ -1263,7 +1264,7 @@ export class VoiceSettingsPanel {
 		const isLocal = (config.ttsBackend ?? "local") === "local";
 		const currentId: string | number = isLocal
 			? (typeof config.ttsLocalVoiceId === "number" ? config.ttsLocalVoiceId : 0)
-			: (config.ttsDeepgramVoiceId ?? "aura-asteria-en");
+			: (config.ttsDeepgramVoiceId ?? DEFAULT_DEEPGRAM_TTS_VOICE);
 		const idx = all.findIndex(v => v.id === currentId);
 		this.ttsVoiceRow = idx >= 0 ? idx : 0;
 		this.sub = "tts-voice-picker";
@@ -1276,7 +1277,7 @@ export class VoiceSettingsPanel {
 		const isLocal = (config.ttsBackend ?? "local") === "local";
 		const currentId: string | number = isLocal
 			? (typeof config.ttsLocalVoiceId === "number" ? config.ttsLocalVoiceId : 0)
-			: (config.ttsDeepgramVoiceId ?? "aura-asteria-en");
+			: (config.ttsDeepgramVoiceId ?? DEFAULT_DEEPGRAM_TTS_VOICE);
 
 		lines.push(`  ${this.bold(isLocal ? "Pick local voice" : "Pick Deepgram voice")}`);
 		const cursor = this.ttsVoiceSearch ? this.ttsVoiceSearch : this.dim("type to filter…");

--- a/extensions/voice/speak.ts
+++ b/extensions/voice/speak.ts
@@ -153,7 +153,7 @@ export async function speak(opts: SpeakOpts): Promise<void> {
 		const sink = openPlaybackStream({ sampleRate: dgSampleRate, signal });
 		if (sink) {
 			try {
-				const voiceId = config.ttsDeepgramVoiceId || "aura-asteria-en";
+				const voiceId = config.ttsDeepgramVoiceId || DEFAULT_DEEPGRAM_TTS_VOICE;
 				for (const chunk of chunks) {
 					if (signal?.aborted) throw makeAbortError();
 					await deepgramSpeakStreaming({

--- a/extensions/voice/tts-deepgram.ts
+++ b/extensions/voice/tts-deepgram.ts
@@ -33,36 +33,37 @@ import type { PlaybackStream } from "./tts-playback";
 // ─── Catalog ──────────────────────────────────────────────────────────────────
 
 /**
- * Subset of Deepgram Aura voices surfaced in the picker. The full Aura
- * catalog is large and changes; we list the stable, well-known voices a
- * coding agent would actually use. Users can override with any voice id
- * supported by Deepgram by setting `ttsDeepgramVoiceId` directly.
+ * Subset of Deepgram Aura-2 voices surfaced in the picker. The full Aura
+ * catalog is large and changes; we list the stable, well-known English
+ * voices a coding agent would actually use. Users can override with any
+ * voice id supported by Deepgram by setting `ttsDeepgramVoiceId` directly.
  *
- * Naming convention: `aura-<name>-<lang>` for Aura-1, `aura-2-<name>-<lang>`
- * for Aura-2. The trailing language code makes language ↔ voice matching
- * a substring check.
+ * Naming convention: `aura-2-<name>-<lang>`. The trailing language code
+ * makes language ↔ voice matching a substring check.
  *
  * Sample rate is the recommended default per Deepgram docs — 24 kHz gives
  * good fidelity and matches the Kitten/Kokoro local pipeline so playback
  * code doesn't need backend-specific buffer handling.
  */
 export const DEEPGRAM_TTS_VOICES = [
-	{ id: "aura-asteria-en", name: "Asteria (en, female, conversational)", language: "en", gender: "female" },
-	{ id: "aura-luna-en", name: "Luna (en, female, polished)", language: "en", gender: "female" },
-	{ id: "aura-stella-en", name: "Stella (en, female, friendly)", language: "en", gender: "female" },
-	{ id: "aura-athena-en", name: "Athena (en, female, mature)", language: "en", gender: "female" },
-	{ id: "aura-hera-en", name: "Hera (en, female, business)", language: "en", gender: "female" },
-	{ id: "aura-orion-en", name: "Orion (en, male, approachable)", language: "en", gender: "male" },
-	{ id: "aura-arcas-en", name: "Arcas (en, male, neutral)", language: "en", gender: "male" },
-	{ id: "aura-perseus-en", name: "Perseus (en, male, confident)", language: "en", gender: "male" },
-	{ id: "aura-angus-en", name: "Angus (en, male, Irish)", language: "en", gender: "male" },
-	{ id: "aura-orpheus-en", name: "Orpheus (en, male, warm)", language: "en", gender: "male" },
-	{ id: "aura-helios-en", name: "Helios (en, male, energetic)", language: "en", gender: "male" },
-	{ id: "aura-zeus-en", name: "Zeus (en, male, deep)", language: "en", gender: "male" },
+	{ id: "aura-2-thalia-en", name: "Thalia (en, female, clear)", language: "en", gender: "female" },
+	{ id: "aura-2-andromeda-en", name: "Andromeda (en, female, expressive)", language: "en", gender: "female" },
+	{ id: "aura-2-amalthea-en", name: "Amalthea (en, female, cheerful)", language: "en", gender: "female" },
+	{ id: "aura-2-apollo-en", name: "Apollo (en, male, confident)", language: "en", gender: "male" },
+	{ id: "aura-2-arcas-en", name: "Arcas (en, male, smooth)", language: "en", gender: "male" },
+	{ id: "aura-2-odysseus-en", name: "Odysseus (en, male, professional)", language: "en", gender: "male" },
+	{ id: "aura-2-asteria-en", name: "Asteria (en, female, knowledgeable)", language: "en", gender: "female" },
+	{ id: "aura-2-athena-en", name: "Athena (en, female, professional)", language: "en", gender: "female" },
+	{ id: "aura-2-helena-en", name: "Helena (en, female, friendly)", language: "en", gender: "female" },
+	{ id: "aura-2-hera-en", name: "Hera (en, female, warm)", language: "en", gender: "female" },
+	{ id: "aura-2-luna-en", name: "Luna (en, female, natural)", language: "en", gender: "female" },
+	{ id: "aura-2-orion-en", name: "Orion (en, male, polite)", language: "en", gender: "male" },
+	{ id: "aura-2-orpheus-en", name: "Orpheus (en, male, trustworthy)", language: "en", gender: "male" },
+	{ id: "aura-2-zeus-en", name: "Zeus (en, male, deep)", language: "en", gender: "male" },
 ] as const;
 
 /** Default Deepgram voice id — used if the user hasn't picked one. */
-export const DEFAULT_DEEPGRAM_TTS_VOICE = "aura-asteria-en";
+export const DEFAULT_DEEPGRAM_TTS_VOICE = "aura-2-thalia-en";
 
 /** Sample rate negotiated with the REST endpoint (Hz). */
 export const DEEPGRAM_TTS_SAMPLE_RATE = 24000;
@@ -252,8 +253,9 @@ export function getDeepgramVoice(id: string): typeof DEEPGRAM_TTS_VOICES[number]
  * show English Aura voices.
  *
  * Region matching is intentionally loose (base tag only) for Deepgram
- * because Aura voice ids carry language without region (e.g. `aura-asteria-en`
- * is American, `aura-angus-en` is Irish — both list `language: "en"`).
+ * because Aura voice ids carry language without region (e.g.
+ * `aura-2-thalia-en` is American and `aura-2-amalthea-en` is Filipino
+ * English — both list `language: "en"`).
  */
 export function filterDeepgramVoicesByLanguage(lang: string): readonly (typeof DEEPGRAM_TTS_VOICES)[number][] {
 	const base = (lang.split("-")[0] ?? "").toLowerCase();

--- a/extensions/voice/tts-deepgram.ts
+++ b/extensions/voice/tts-deepgram.ts
@@ -33,13 +33,16 @@ import type { PlaybackStream } from "./tts-playback";
 // ─── Catalog ──────────────────────────────────────────────────────────────────
 
 /**
- * Subset of Deepgram Aura-2 voices surfaced in the picker. The full Aura
+ * Subset of Deepgram Aura voices surfaced in the picker. The full Aura
  * catalog is large and changes; we list the stable, well-known English
- * voices a coding agent would actually use. Users can override with any
- * voice id supported by Deepgram by setting `ttsDeepgramVoiceId` directly.
+ * voices a coding agent would actually use. Aura 2 voices are listed first
+ * so the picker defaults to the newer models while still exposing Aura 1.
+ * Users can override with any voice id supported by Deepgram by setting
+ * `ttsDeepgramVoiceId` directly.
  *
- * Naming convention: `aura-2-<name>-<lang>`. The trailing language code
- * makes language ↔ voice matching a substring check.
+ * Naming convention: `aura-<name>-<lang>` for Aura 1,
+ * `aura-2-<name>-<lang>` for Aura 2. The trailing language code makes
+ * language ↔ voice matching a substring check.
  *
  * Sample rate is the recommended default per Deepgram docs — 24 kHz gives
  * good fidelity and matches the Kitten/Kokoro local pipeline so playback
@@ -60,6 +63,18 @@ export const DEEPGRAM_TTS_VOICES = [
 	{ id: "aura-2-orion-en", name: "Orion (en, male, polite)", language: "en", gender: "male" },
 	{ id: "aura-2-orpheus-en", name: "Orpheus (en, male, trustworthy)", language: "en", gender: "male" },
 	{ id: "aura-2-zeus-en", name: "Zeus (en, male, deep)", language: "en", gender: "male" },
+	{ id: "aura-asteria-en", name: "Asteria (en, female, conversational)", language: "en", gender: "female" },
+	{ id: "aura-luna-en", name: "Luna (en, female, polished)", language: "en", gender: "female" },
+	{ id: "aura-stella-en", name: "Stella (en, female, friendly)", language: "en", gender: "female" },
+	{ id: "aura-athena-en", name: "Athena (en, female, mature)", language: "en", gender: "female" },
+	{ id: "aura-hera-en", name: "Hera (en, female, business)", language: "en", gender: "female" },
+	{ id: "aura-orion-en", name: "Orion (en, male, approachable)", language: "en", gender: "male" },
+	{ id: "aura-arcas-en", name: "Arcas (en, male, neutral)", language: "en", gender: "male" },
+	{ id: "aura-perseus-en", name: "Perseus (en, male, confident)", language: "en", gender: "male" },
+	{ id: "aura-angus-en", name: "Angus (en, male, Irish)", language: "en", gender: "male" },
+	{ id: "aura-orpheus-en", name: "Orpheus (en, male, warm)", language: "en", gender: "male" },
+	{ id: "aura-helios-en", name: "Helios (en, male, energetic)", language: "en", gender: "male" },
+	{ id: "aura-zeus-en", name: "Zeus (en, male, deep)", language: "en", gender: "male" },
 ] as const;
 
 /** Default Deepgram voice id — used if the user hasn't picked one. */
@@ -254,8 +269,7 @@ export function getDeepgramVoice(id: string): typeof DEEPGRAM_TTS_VOICES[number]
  *
  * Region matching is intentionally loose (base tag only) for Deepgram
  * because Aura voice ids carry language without region (e.g.
- * `aura-2-thalia-en` is American and `aura-2-amalthea-en` is Filipino
- * English — both list `language: "en"`).
+ * `aura-2-thalia-en` and `aura-asteria-en` both list `language: "en"`).
  */
 export function filterDeepgramVoicesByLanguage(lang: string): readonly (typeof DEEPGRAM_TTS_VOICES)[number][] {
 	const base = (lang.split("-")[0] ?? "").toLowerCase();
@@ -268,7 +282,7 @@ export function filterDeepgramVoicesByLanguage(lang: string): readonly (typeof D
  * the speak orchestrator before any network call so language ↔ voice
  * mismatches surface immediately rather than after a wasted round trip.
  *
- * Voices not in the surfaced catalog (custom Aura-2 ids the user pasted
+ * Voices not in the surfaced catalog (custom Aura ids the user pasted
  * directly into config) are accepted on faith — Deepgram's server will
  * reject if invalid.
  */

--- a/extensions/voice/tts-text-filter.ts
+++ b/extensions/voice/tts-text-filter.ts
@@ -208,9 +208,11 @@ export function prepareForSpeech(input: string, opts: PrepareForSpeechOpts = {})
 	text = text.replace(/([!?.])\1{2,}/g, "$1");
 	text = text.replace(/-{3,}/g, " ");
 
-	// 15. Collapse whitespace runs. Keep paragraph breaks (double newline)
-	//     because the segmenter uses them; everything else becomes a
-	//     single space.
+	// 15. Collapse whitespace runs. Keep a single paragraph break (double
+	//     newline) because TTS engines use it as a natural pause boundary,
+	//     but normalize whitespace-only blank-line runs so agent output
+	//     padded with spaces does not synthesize as long silence.
+	text = text.replace(/[ \t]*\r?\n[ \t]*/g, "\n");
 	text = text.replace(/[ \t]+/g, " ");
 	text = text.replace(/\n{3,}/g, "\n\n");
 	text = text.trim();

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   },
   "devDependencies": {
     "@mariozechner/pi-coding-agent": "^0.70.5",
-    "@mariozechner/pi-tui": "^0.70.5"
+    "@mariozechner/pi-tui": "^0.70.5",
+    "@types/ws": "^8.18.1"
   },
   "pi": {
     "extensions": [
@@ -70,5 +71,8 @@
   ],
   "optionalDependencies": {
     "sherpa-onnx-node": "^1.13.0"
+  },
+  "dependencies": {
+    "ws": "^8.20.1"
   }
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -43,6 +43,7 @@ describe("loadConfigWithSource", () => {
 		expect(result.config.enabled).toBe(true);
 		expect(result.config.onboarding.completed).toBe(false);
 		expect(result.config.scope).toBe("global");
+		expect(result.config.ttsDeepgramVoiceId).toBe("aura-2-thalia-en");
 	});
 
 	test("migrates legacy global config and marks onboarding complete when backend and model were explicit", () => {

--- a/tests/tts-deepgram.test.ts
+++ b/tests/tts-deepgram.test.ts
@@ -10,12 +10,12 @@ import {
 
 describe("buildDeepgramSpeakUrl", () => {
 	test("builds the expected URL shape", () => {
-		const url = buildDeepgramSpeakUrl("aura-asteria-en", 24000);
-		expect(url).toBe("https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&sample_rate=24000&container=wav");
+		const url = buildDeepgramSpeakUrl("aura-2-thalia-en", 24000);
+		expect(url).toBe("https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate=24000&container=wav");
 	});
 
 	test("includes the requested sample rate", () => {
-		const url = buildDeepgramSpeakUrl("aura-luna-en", 16000);
+		const url = buildDeepgramSpeakUrl("aura-2-luna-en", 16000);
 		expect(url).toContain("sample_rate=16000");
 	});
 
@@ -31,6 +31,21 @@ describe("buildDeepgramSpeakUrl", () => {
 describe("DEEPGRAM_TTS_VOICES catalog", () => {
 	test("default voice exists", () => {
 		expect(DEEPGRAM_TTS_VOICES.find(v => v.id === DEFAULT_DEEPGRAM_TTS_VOICE)).toBeDefined();
+		expect(DEFAULT_DEEPGRAM_TTS_VOICE).toBe("aura-2-thalia-en");
+	});
+
+	test("surfaces requested Aura-2 voices", () => {
+		const ids = new Set(DEEPGRAM_TTS_VOICES.map(v => v.id));
+		for (const id of [
+			"aura-2-thalia-en",
+			"aura-2-odysseus-en",
+			"aura-2-amalthea-en",
+			"aura-2-andromeda-en",
+			"aura-2-apollo-en",
+			"aura-2-arcas-en",
+		]) {
+			expect(ids.has(id)).toBe(true);
+		}
 	});
 
 	test("every voice has language and gender", () => {
@@ -41,7 +56,7 @@ describe("DEEPGRAM_TTS_VOICES catalog", () => {
 	});
 
 	test("getDeepgramVoice returns by id", () => {
-		expect(getDeepgramVoice("aura-asteria-en")?.id).toBe("aura-asteria-en");
+		expect(getDeepgramVoice("aura-2-thalia-en")?.id).toBe("aura-2-thalia-en");
 	});
 
 	test("getDeepgramVoice returns undefined for unknown id", () => {
@@ -72,19 +87,19 @@ describe("filterDeepgramVoicesByLanguage", () => {
 
 describe("assertLanguageForDeepgram", () => {
 	test("matched voice + language passes", () => {
-		expect(() => assertLanguageForDeepgram("aura-asteria-en", "en")).not.toThrow();
+		expect(() => assertLanguageForDeepgram("aura-2-thalia-en", "en")).not.toThrow();
 	});
 
 	test("regional language matches base", () => {
-		expect(() => assertLanguageForDeepgram("aura-asteria-en", "en-US")).not.toThrow();
+		expect(() => assertLanguageForDeepgram("aura-2-thalia-en", "en-US")).not.toThrow();
 	});
 
 	test("language mismatch throws actionable error", () => {
-		expect(() => assertLanguageForDeepgram("aura-asteria-en", "es-ES")).toThrow(/aura-asteria-en speaks en/);
+		expect(() => assertLanguageForDeepgram("aura-2-thalia-en", "es-ES")).toThrow(/aura-2-thalia-en speaks en/);
 	});
 
 	test("empty language throws", () => {
-		expect(() => assertLanguageForDeepgram("aura-asteria-en", "")).toThrow();
+		expect(() => assertLanguageForDeepgram("aura-2-thalia-en", "")).toThrow();
 	});
 
 	test("unknown voice id is accepted (let server validate)", () => {

--- a/tests/tts-deepgram.test.ts
+++ b/tests/tts-deepgram.test.ts
@@ -48,6 +48,30 @@ describe("DEEPGRAM_TTS_VOICES catalog", () => {
 		}
 	});
 
+	test("surfaces legacy Aura voices below Aura-2 voices", () => {
+		const ids = new Set(DEEPGRAM_TTS_VOICES.map(v => v.id));
+		for (const id of [
+			"aura-asteria-en",
+			"aura-luna-en",
+			"aura-stella-en",
+			"aura-athena-en",
+			"aura-hera-en",
+			"aura-orion-en",
+			"aura-arcas-en",
+			"aura-perseus-en",
+			"aura-angus-en",
+			"aura-orpheus-en",
+			"aura-helios-en",
+			"aura-zeus-en",
+		]) {
+			expect(ids.has(id)).toBe(true);
+		}
+
+		const firstLegacyAuraIndex = DEEPGRAM_TTS_VOICES.findIndex(v => v.id.startsWith("aura-") && !v.id.startsWith("aura-2-"));
+		const lastAura2Index = DEEPGRAM_TTS_VOICES.findLastIndex(v => v.id.startsWith("aura-2-"));
+		expect(firstLegacyAuraIndex).toBeGreaterThan(lastAura2Index);
+	});
+
 	test("every voice has language and gender", () => {
 		for (const v of DEEPGRAM_TTS_VOICES) {
 			expect(v.language).toBeDefined();

--- a/tests/tts-text-filter.test.ts
+++ b/tests/tts-text-filter.test.ts
@@ -107,6 +107,17 @@ describe("prepareForSpeech — list markers", () => {
 	});
 });
 
+describe("prepareForSpeech — paragraph spacing", () => {
+	test("collapses whitespace-only blank-line runs to one paragraph break", () => {
+		const input = "Updated Source Link definition to component-level evidence.   \n   \n   \n Question 436\n \n \n Should Source Link Matching require the linked Authority Event itself to be fresh?\n \n \n Current relationships say yes.";
+		const r = prepareForSpeech(input);
+		expect(r.skipped).toBe(false);
+		expect(r.text).toBe("Updated Source Link definition to component-level evidence.\n\nQuestion four hundred thirty-six\n\nShould Source Link Matching require the linked Authority Event itself to be fresh?\n\nCurrent relationships say yes.");
+		expect(r.text).not.toMatch(/\n{3,}/);
+		expect(r.text).not.toMatch(/\n[ \t]+\n/);
+	});
+});
+
 describe("prepareForSpeech — length cap", () => {
 	test("rejects when output exceeds maxChars", () => {
 		const long = "word ".repeat(500); // ~2500 chars


### PR DESCRIPTION
## Description

Adds Deepgram Aura 2 voices to the TTS voice catalog and makes `aura-2-thalia-en` the default Deepgram TTS voice. Keeps the original Aura voices available below Aura 2 in the picker so existing voice preferences remain discoverable.

This PR also includes a few related voice-path fixes: shared Deepgram default voice usage instead of hardcoded fallbacks, whitespace-only paragraph normalization before TTS synthesis, and exact `ArrayBuffer` frame sending for Deepgram STT WebSocket audio chunks.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Test addition/update

## Changes Made

- Add Aura 2 Deepgram TTS voices and default Deepgram TTS to `aura-2-thalia-en`
- Restore the original Aura voices below Aura 2 in the Deepgram voice catalog
- Use the exported Deepgram default voice instead of hardcoded `aura-asteria-en` fallbacks
- Normalize whitespace-only paragraph breaks before TTS synthesis
- Send Deepgram STT WebSocket audio chunks as exact `ArrayBuffer` frames
- Add regression coverage for Aura 2 voices, legacy Aura voices, default config, paragraph spacing, and voice ordering
- Add an `[Unreleased]` changelog entry

## Testing

- [x] `bun run check` passes (typecheck + test)
- [x] New tests added for new functionality
- [x] Existing tests still pass
- [x] Manual testing performed

### Manual Testing Steps

1. Configure TTS backend to Deepgram
2. Open the TTS voice picker
3. Confirm Aura 2 voices appear first
4. Confirm legacy Aura voices appear below Aura 2
5. Confirm the default Deepgram voice is `aura-2-thalia-en`
6. Speak a response with whitespace-separated paragraphs and confirm pauses are natural

## Screenshots / Output

```text
bun run check
274 pass
0 fail
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated the CHANGELOG.md
- [x] I have updated documentation (if applicable)
- [x] No secrets or tokens are included in the code